### PR TITLE
Limit the lenghts and utility change

### DIFF
--- a/index.php
+++ b/index.php
@@ -15,7 +15,7 @@
       // Path of upload/ directory
       $uploadDirectoryPath = "upload/";
       // Regular expression of a URL (incomplete)
-      $regexURL = "#^https?:\/\/([a-z\d-_]{2,}\.){1,}[a-z]{2,20}\/?#i";
+      $regexURL = "#^https?:\/\/([\w-]{2,63}\.){1,}\w{1,2000}[a-z]{2,20}\/?#i";
       // Regular expression of an image file
       $regexImages = "#([^\"']*\.(jpe?g|a?png|bmp|tiff|svg))#i";
 


### PR DESCRIPTION
Limit the sub-domains length to 63 chars (RFC 1035, section 2.3.1) and limit the URI length to 2000 (RFC 7230, section 3.1.1).
Also an utility change to the range groups.

Regex101 proof: https://regex101.com/r/1EEd4p/3

**RFC 1035, section 2.3.1:** 
https://tools.ietf.org/html/rfc1035#section-2.3.1
`"The labels must follow the rules for ARPANET host names. They must start with a letter, end with a letter or digit, and have as interior characters only letters, digits, and hyphen. There are also some restrictions on the length. Labels must be 63 characters or less."`

**RFC 7230, section 3.1.1:**
https://tools.ietf.org/html/rfc7230#section-3.1.1
`"It is RECOMMENDED that all HTTP senders and recipients support, at a minimum, request-line lengths of 8000 octets [...] A server that receives a request-target longer than any URI it wishes to parse MUST respond with a 414 (URI Too Long) status code (see Section 6.5.12 of [RFC7231])"`